### PR TITLE
Remove support for DataStructure in DatasetHttpMessageConverter

### DIFF
--- a/java-vtl-connectors-spring/src/main/java/no/ssb/vtl/connectors/spring/converters/DatasetHttpMessageConverter.java
+++ b/java-vtl-connectors-spring/src/main/java/no/ssb/vtl/connectors/spring/converters/DatasetHttpMessageConverter.java
@@ -70,7 +70,6 @@ import static no.ssb.vtl.model.Order.BY_ROLE;
  * A converter that support the following conversions
  * <p>
  * Read:
- * application/ssb.dataset+json;version=2 -> DataStructure
  * application/ssb.dataset+json;version=2 -> Stream<DataPoint>
  * <p>
  * Write:
@@ -131,7 +130,6 @@ public class DatasetHttpMessageConverter extends MappingJackson2HttpMessageConve
 
     private boolean canRead(TypeToken<?> token, MediaType mediaType) {
         return canRead(mediaType) && (token.isSupertypeOf(STREAM_TYPE_TOKEN) ||
-                token.isSupertypeOf(DataStructure.class) ||
                 token.isSupertypeOf(Dataset.class));
     }
 


### PR DESCRIPTION
The java http client require connections to be emptied in order to reuse them. 
In the cases where the datasets are big, asking for the data structure using application/ssb.dataset means that the entire data needs to be transfered.
  