### PR TITLE
Handlke IllegalArgumentException

### DIFF
--- a/java-vtl-connectors-ssb/src/test/java/no/ssb/vtl/connectors/PxApiConnectorTest.java
+++ b/java-vtl-connectors-ssb/src/test/java/no/ssb/vtl/connectors/PxApiConnectorTest.java
@@ -36,6 +36,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -103,8 +106,6 @@ public class PxApiConnectorTest {
         boolean canHandle = connector.canHandle("http://data.ssb.no/api/v0/no/table/09220");
         assertThat(canHandle).isTrue();
     }
-    
-    
 }
 
 


### PR DESCRIPTION
After the migration to Spring boot 2 we started getting IllegalArgumentException from the method getULR() of the URI passed to SpringTemplate signaling a non absolute uri. I am not sure why this started and I could not reproduce consistently. This PR handle the exception and returns an error message including the faulty uri.