### PR TITLE
KP-3689: data-service logger errors every 5 mins

### DIFF
--- a/java-vtl-connectors-spring/src/main/java/no/ssb/vtl/connectors/spring/converters/DataHttpConverter.java
+++ b/java-vtl-connectors-spring/src/main/java/no/ssb/vtl/connectors/spring/converters/DataHttpConverter.java
@@ -123,7 +123,11 @@ public class DataHttpConverter extends AbstractGenericHttpMessageConverter<Strea
      * @see #canWrite(Class, MediaType)
      */
     private boolean canWrite(TypeToken<?> token, MediaType mediaType) {
-        return token.isSubtypeOf(SUPPORTED_TYPE) && canRead(mediaType);
+        try {
+            return token.isSubtypeOf(SUPPORTED_TYPE) && canRead(mediaType);
+        } catch (AssertionError e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
When accessing actuator-endpoints from spring boot admin. ResolvableType.EmtpyType is set.
AssertionError is thrown and causes data-service-exceptions if type == ResolvableType.EmptyType. 
Will now catch such exceptions and return false.